### PR TITLE
GS 754

### DIFF
--- a/types.go
+++ b/types.go
@@ -69,7 +69,7 @@ var ParamTagMap = map[string]ParamValidator{
 
 // ParamTagRegexMap maps param tags to their respective regexes.
 var ParamTagRegexMap = map[string]*regexp.Regexp{
-	"range":        regexp.MustCompile("^range\\((\\d+)\\|(\\d+)\\)$"),
+	"range":        regexp.MustCompile("^range\\((\\d*\\.?\\d*)\\|(\\d*\\.?\\d*)\\)$"),
 	"length":       regexp.MustCompile("^length\\((\\d+)\\|(\\d+)\\)$"),
 	"runelength":   regexp.MustCompile("^runelength\\((\\d+)\\|(\\d+)\\)$"),
 	"stringlength": regexp.MustCompile("^stringlength\\((\\d+)\\|(\\d+)\\)$"),


### PR DESCRIPTION
You couldn't have decimal places in the numbers for the range validation tag. Now you can.