### PR TITLE
Add left and right quotation marks to characters allowed in validation tags

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -791,7 +791,7 @@ func isValidTag(s string) bool {
 	}
 	for _, c := range s {
 		switch {
-		case strings.ContainsRune("\\'\"!#$%&()*+-./:<=>?@[]^_{|}~, ", c):
+		case strings.ContainsRune("\\'\"!#$%&()*+-./:<=>?@[]^_{|}~, ‘’", c):
 			// Backslash and quote chars are reserved, but
 			// otherwise any punctuation chars are allowed
 			// in a tag name.


### PR DESCRIPTION
This lets us use ‘ and ’ (left and right quotation marks) in validation tags like matches