### PR TITLE
Update go.mod to use skybet/goback - h2so5/goback was deleted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/skybet/govalidator
 
 go 1.12
 
-require github.com/h2so5/goback v0.0.0-20150302055225-6e210305bfc9
+require github.com/skybet/goback v0.0.0-20150302055225-6e210305bfc9


### PR DESCRIPTION
commit hash should be the same so just `h2s05` -> `skybet`